### PR TITLE
Add CORS middleware to server configuration

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,7 +27,8 @@ func (s *Server) setupServer() {
 	s.e.Use(middleware.Recover())
 	s.e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
 		Format: `{"time": "${time_rfc3339}", "method": "${method}", "uri": "${uri}", "status": "${status}", "remote_ip": "${remote_ip}"}` + "\n"}))
-
+	s.e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins: []string{"*"}}))
 	s.setupRoutes()
 }
 


### PR DESCRIPTION
This commit adds CORS middleware to allow cross-origin resource sharing. It is a necessary implementation to allow client-side web application to interact with the server resources apart from the same origin.