### PR TITLE
Update golangci-lint workflow trigger

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,6 +1,5 @@
 name: golangci-lint
 on:
-  push:
   pull_request:
     branches:
       - dev


### PR DESCRIPTION
This commit removes the "push" trigger from the golangci-lint GitHub workflow to ensure linting only occurs on pull requests rather than on every push. This change minimizes unnecessary run of the workflow, reducing resource usage.